### PR TITLE
Fix builtins not being bundled issue

### DIFF
--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -186,7 +186,10 @@ const generateConfig = (bundleType, polyfill, env) => {
             config.plugins.push(terserCommentsOffPlugin);
         } else {
             config.plugins.push(terser());
-            config.plugins.push(autoExternal({ dependencies: false }));
+            // To avoid `Missing shims` and `Missing global variable` warnings.
+            if (bundleType !== UMD_BUNDLE) {
+                config.plugins.push(autoExternal({ dependencies: false, builtins: false }));
+            }
 
             config.output.globals = {
                 axios: "axios"


### PR DESCRIPTION
## Purpose
>  This makes sure `buffer` and `process` are bundled with the bundle files.