### PR TITLE
Add an option to send cookies in the request header

### DIFF
--- a/packages/oidc-js/src/client.ts
+++ b/packages/oidc-js/src/client.ts
@@ -67,6 +67,7 @@ const DefaultConfig = {
     enablePKCE: true,
     responseMode: null,
     scope: [OIDC_SCOPE],
+    sendCookiesInRequest: false,
     validateIDToken: true
 };
 

--- a/packages/oidc-js/src/models/client.ts
+++ b/packages/oidc-js/src/models/client.ts
@@ -43,6 +43,10 @@ interface BaseConfigInterface {
      * Allowed leeway for id_tokens (in seconds).
      */
     clockTolerance?: number;
+    /**
+     * Send cookie headers with request.
+     */
+    sendCookiesInRequest?: boolean;
 }
 
 /**

--- a/packages/oidc-js/src/utils/sign-in.ts
+++ b/packages/oidc-js/src/utils/sign-in.ts
@@ -217,7 +217,7 @@ export function validateIdToken(
     }
 
     return axios
-        .get(jwksEndpoint)
+        .get(jwksEndpoint, { withCredentials: requestParams.sendCookiesInRequest })
         .then((response) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to load public keys from JWKS URI: " + jwksEndpoint));
@@ -307,7 +307,10 @@ export function sendTokenRequest(
     }
 
     return axios
-        .post(tokenEndpoint, body.join("&"), { headers: getTokenRequestHeaders() })
+        .post(tokenEndpoint, body.join("&"), {
+            headers: getTokenRequestHeaders(),
+            withCredentials: requestParams.sendCookiesInRequest
+        })
         .then((response) => {
             if (response.status !== 200) {
                 return Promise.reject(
@@ -384,7 +387,10 @@ export function sendRefreshTokenRequest(
     }
 
     return axios
-        .post(tokenEndpoint, body.join("&"), { headers: getTokenRequestHeaders() })
+        .post(tokenEndpoint, body.join("&"), {
+            headers: getTokenRequestHeaders(),
+            withCredentials: requestParams.sendCookiesInRequest
+        })
         .then((response) => {
             if (response.status !== 200) {
                 return Promise.reject(
@@ -460,7 +466,7 @@ export function sendRevokeTokenRequest(
     return axios
         .post(revokeTokenEndpoint, body.join("&"), {
             headers: getTokenRequestHeaders(),
-            withCredentials: true
+            withCredentials: requestParams.sendCookiesInRequest
         })
         .then((response) => {
             if (response.status !== 200) {


### PR DESCRIPTION
## Purpose

Currently, the requests sent from the sdk to get access token, get refresh token etc. do not send the cookies with the request. This fix introduces an option to enable sending the cookies in the request header if required.

A new config named `sendCookiesInRequest` is introduced for this purpose. This is set to `false` by default. If it is required to send the cookies with the requests, `sendCookiesInRequest` should be set to `true` when initializing the sdk.
