### PR TITLE
Update the idtoken decoding technique with base64url library

### DIFF
--- a/packages/oidc-js/package-lock.json
+++ b/packages/oidc-js/package-lock.json
@@ -1547,6 +1547,11 @@
 				}
 			}
 		},
+		"base64url": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+		},
 		"binary-extensions": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",

--- a/packages/oidc-js/package.json
+++ b/packages/oidc-js/package.json
@@ -27,6 +27,7 @@
         "@babel/runtime-corejs3": "^7.11.2",
         "await-semaphore": "^0.1.3",
         "axios": "^0.21.0",
+        "base64url": "^3.0.1",
         "crypto-js": "^3.1.9-1"
     },
     "devDependencies": {

--- a/packages/oidc-js/src/utils/sign-in.ts
+++ b/packages/oidc-js/src/utils/sign-in.ts
@@ -74,6 +74,7 @@ import {
     UserInfo,
     WebWorkerConfigInterface
 } from "../models";
+import base64url from "base64url";
 
 /**
  * Checks whether authorization code is present.
@@ -489,7 +490,7 @@ export function sendRevokeTokenRequest(
  * @returns {AuthenticatedUserInterface} authenticated user.
  */
 export const getAuthenticatedUser = (idToken: string): AuthenticatedUserInterface => {
-    const payload: DecodedIdTokenPayloadInterface = JSON.parse(atob(idToken?.split(".")[1]));
+    const payload: DecodedIdTokenPayloadInterface = JSON.parse(base64url.decode(idToken?.split(".")[1], "utf8"));
     const emailAddress: string = payload.email ? payload.email : null;
     const tenantDomain: string = getTenantDomainFromIdTokenPayload(payload);
 
@@ -727,7 +728,7 @@ export const getDecodedIDToken = (
     config: ConfigInterface | WebWorkerConfigInterface
 ): DecodedIdTokenPayloadInterface => {
     const idToken = getSessionParameter(ID_TOKEN, config);
-    const payload: DecodedIdTokenPayloadInterface = JSON.parse(atob(idToken.split(".")[1]));
+    const payload: DecodedIdTokenPayloadInterface = JSON.parse(base64url.decode(idToken.split(".")[1], "utf8"));
 
     return payload;
 };

--- a/packages/oidc-js/src/utils/sign-in.ts
+++ b/packages/oidc-js/src/utils/sign-in.ts
@@ -17,6 +17,7 @@
  */
 
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import base64url from "base64url";
 import { KeyLike } from "jose/webcrypto/types";
 import { getCodeChallenge, getCodeVerifier, getJWKForTheIdToken, isValidIdToken } from "./crypto";
 import {
@@ -74,7 +75,6 @@ import {
     UserInfo,
     WebWorkerConfigInterface
 } from "../models";
-import base64url from "base64url";
 
 /**
  * Checks whether authorization code is present.


### PR DESCRIPTION
## Purpose
Update the `idtoken` decoding technique from atob(ASCII to binary) to base64url.

## Related Issues
Fixes https://github.com/wso2-enterprise/asgardeo-product/issues/4536

## Goals
Avoid the occurance of ID token validation/decoding issues in the sign-in pages of console and myaccount apps. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> None
