### PR TITLE
Optional token endpoint for custom grant configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,6 +969,7 @@ const config: AuthClientConfig<Bar> ={
 | `signInRequired` | Required          | `boolean` | `false`       | Specifies if the user should be sign-in or not to dispatch this custom-grant request.                                                                                                                                         |
 | `attachToken`    | Required          | `boolean` | `false`       | Specifies if the access token should be attached to the header of the request.                                                                                                                                                |
 | `returnsSession` | Required          | `boolean` | `false`       | Specifies if the the request returns session information such as the access token.                                                                                                                                            |
+| `tokenEndpoint`  | Optional          | `string`  | `null`        | Token endpoint is an optional parameter which can be used to provide an optional token endpoint that will be used instead of default token endpoint.                                                                          | 
 
 #### Custom Grant Template Tags
 

--- a/lib/src/core/authentication-core.ts
+++ b/lib/src/core/authentication-core.ts
@@ -331,7 +331,14 @@ export class AuthenticationCore<T> {
     public async requestCustomGrant(customGrantParams: CustomGrantConfig): Promise<TokenResponse | AxiosResponse> {
         const oidcProviderMetadata = await this._oidcProviderMetaData();
 
-        if (!oidcProviderMetadata.token_endpoint || oidcProviderMetadata.token_endpoint.trim().length === 0) {
+        let tokenEndpoint;
+        if (customGrantParams.tokenEndpoint && customGrantParams.tokenEndpoint.trim().length !== 0) {
+            tokenEndpoint = customGrantParams.tokenEndpoint;
+        } else {
+            tokenEndpoint = oidcProviderMetadata.token_endpoint;
+        }
+
+        if (!tokenEndpoint || tokenEndpoint.trim().length === 0) {
             return Promise.reject(
                 new AsgardeoAuthException(
                     "AUTH_CORE-RCG-NF01",
@@ -357,7 +364,7 @@ export class AuthenticationCore<T> {
                 ...AuthenticationUtils.getTokenRequestHeaders()
             },
             method: "POST",
-            url: oidcProviderMetadata.token_endpoint
+            url: tokenEndpoint
         };
 
         if (customGrantParams.attachToken) {

--- a/lib/src/models/custom-grant.ts
+++ b/lib/src/models/custom-grant.ts
@@ -22,4 +22,5 @@ export interface CustomGrantConfig{
     signInRequired: boolean;
     attachToken: boolean;
     returnsSession: boolean;
+    tokenEndpoint?: string;
 }


### PR DESCRIPTION
## Purpose
This PR:

-  resolves: #145 
-  updates README

## Goals
Above mentioned issue id fixed by adding an optional token endpoint to the custom grant configuration and if that endpoint is provided, that is set as the token endpoint of `requestCustomGrant` method.

## Related issues
wso2-enterprise/choreo#6561
