### PR TITLE
Introduce a config attribute to send cookies and improve models 

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ This model has the following attributes.
 |`wellKnownEndpoint`|Optional| `string`|`"/oauth2/token/.well-known/openid-configuration"`| The URL of the `.well-known` endpoint.|
 |`validateIDToken`|Optional| `boolean`|`true`|Allows you to enable/disable JWT ID token validation after obtaining the ID token.|
 |`clockTolerance`|Optional| `number`|`60`|Allows you to configure the leeway when validating the id_token.|
+|`sendCookiesInRequests`|Optional| `boolean`|`true`|Specifies if cookies should be sent in the requests.|
 
 The `AuthClientConfig<T>` can be extended by passing an interface as the generic type. For example, if you want to add an attribute called `foo` to the config object, you can create an interface called `Bar` and pass that as the generic type into the `AuthClientConfig<T>` interface.
 

--- a/lib/src/authentication-client.ts
+++ b/lib/src/authentication-client.ts
@@ -40,6 +40,7 @@ const DefaultConfig: Partial<AuthClientConfig<unknown>> = {
     enablePKCE: true,
     responseMode: ResponseMode.query,
     scope: [OIDC_SCOPE],
+    sendCookiesInRequests: true,
     validateIDToken: true
 };
 

--- a/lib/src/core/authentication-core.ts
+++ b/lib/src/core/authentication-core.ts
@@ -154,7 +154,10 @@ export class AuthenticationCore<T> {
         }
 
         return axios
-            .post(tokenEndpoint, body.join("&"), { headers: AuthenticationUtils.getTokenRequestHeaders() })
+            .post(tokenEndpoint, body.join("&"), {
+                headers: AuthenticationUtils.getTokenRequestHeaders(),
+                withCredentials: configData.sendCookiesInRequests
+            })
             .then((response) => {
                 return this._authenticationHelper
                     .handleTokenResponse(response)
@@ -230,7 +233,10 @@ export class AuthenticationCore<T> {
         }
 
         return axios
-            .post(tokenEndpoint, body.join("&"), { headers: AuthenticationUtils.getTokenRequestHeaders() })
+            .post(tokenEndpoint, body.join("&"), {
+                headers: AuthenticationUtils.getTokenRequestHeaders(),
+                withCredentials: configData.sendCookiesInRequests
+            })
             .then((response) => {
                 return this._authenticationHelper
                     .handleTokenResponse(response)
@@ -290,7 +296,7 @@ export class AuthenticationCore<T> {
         return axios
             .post(revokeTokenEndpoint, body.join("&"), {
                 headers: AuthenticationUtils.getTokenRequestHeaders(),
-                withCredentials: true
+                withCredentials: configData.sendCookiesInRequests
             })
             .then((response) => {
                 if (response.status !== 200) {
@@ -330,6 +336,7 @@ export class AuthenticationCore<T> {
 
     public async requestCustomGrant(customGrantParams: CustomGrantConfig): Promise<TokenResponse | AxiosResponse> {
         const oidcProviderMetadata = await this._oidcProviderMetaData();
+        const configData = await this._config();
 
         let tokenEndpoint;
         if (customGrantParams.tokenEndpoint && customGrantParams.tokenEndpoint.trim().length !== 0) {
@@ -364,7 +371,8 @@ export class AuthenticationCore<T> {
                 ...AuthenticationUtils.getTokenRequestHeaders()
             },
             method: "POST",
-            url: tokenEndpoint
+            url: tokenEndpoint,
+            withCredentials: configData.sendCookiesInRequests
         };
 
         if (customGrantParams.attachToken) {

--- a/lib/src/helpers/authentication-helper.ts
+++ b/lib/src/helpers/authentication-helper.ts
@@ -112,6 +112,7 @@ export class AuthenticationHelper<T> {
 
     public async validateIdToken(idToken: string): Promise<boolean> {
         const jwksEndpoint = (await this._dataLayer.getOIDCProviderMetaData()).jwks_uri;
+        const configData = await this._config();
 
         if (!jwksEndpoint || jwksEndpoint.trim().length === 0) {
             return Promise.reject(
@@ -127,7 +128,7 @@ export class AuthenticationHelper<T> {
         }
 
         return axios
-            .get(jwksEndpoint)
+            .get(jwksEndpoint, { withCredentials: configData?.sendCookiesInRequests })
             .then(async (response) => {
                 if (response.status !== 200) {
                     return Promise.reject(

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -38,6 +38,12 @@ export interface StrictAuthClientConfig {
      * Allowed leeway for id_tokens (in seconds).
      */
     clockTolerance?: number;
+    /**
+     * Specifies if cookies should be sent with access-token requests, refresh-token requests,
+     * custom-grant requests, etc.
+     *
+     */
+    sendCookiesInRequests: boolean;
 }
 
 export type AuthClientConfig<T = unknown> = StrictAuthClientConfig & T;

--- a/lib/src/models/user.ts
+++ b/lib/src/models/user.ts
@@ -23,7 +23,7 @@ export interface BasicUserInfo {
     allowedScopes: string;
     tenantDomain?: string | undefined;
     sessionState: string;
-    [ key: string ]: string | undefined;
+    [ key: string ]: any;
 }
 
 /**
@@ -55,5 +55,5 @@ export interface AuthenticatedUserInfo {
      * Authenticated user's username.
      */
     username: string;
-    [key: string]: string | undefined;
+    [key: string]: any;
 }


### PR DESCRIPTION
## Purpose
>This PR introduces an attribute called `sendCookiesInRequests` to toggle sending cookies with requests.
> This PR also improves the `BasicUserInfo` and `AuthenticatedUserInfo` interfaces.
