### PR TITLE
Fix ID token validation bug

### DIFF
--- a/lib/src/core/authentication-core.ts
+++ b/lib/src/core/authentication-core.ts
@@ -552,7 +552,7 @@ export class AuthenticationCore<T> {
                 "AUTH_CORE-GSOU-NF02",
                 "authentication-core",
                 "getSignOutURL",
-                "ID token n0t found.",
+                "ID token not found.",
                 "No ID token could be found. Either the session information is lost or you have not signed in."
             );
         }

--- a/lib/src/helpers/authentication-helper.ts
+++ b/lib/src/helpers/authentication-helper.ts
@@ -158,7 +158,7 @@ export class AuthenticationHelper<T> {
                             jwk,
                             (await this._config()).clientID,
                             issuer,
-                            AuthenticationUtils.getAuthenticatedUserInfo(idToken).username,
+                            CryptoUtils.decodeIDToken(idToken).sub,
                             (await this._config()).clockTolerance
                         )
                             .then((response) => response)


### PR DESCRIPTION
## Purpose
> At present, the username extracted from the `sub` attribute of the ID token payload is passed as the `sub` argument into the ID token validation function. This results in the DI token being invalidated when used with a SaaS app. This happens because the SaaS apps append the tenant domain to the `sub` attribute. When the username is extracted from the `sub` attribute, the tenant name is removed. 

This PR passes the `sub` attribute to the ID token validation function to fix this issue.
