### PR TITLE
Add `sub` attribute to Authenticated state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,6 +1075,7 @@ type StoreValue = string | string[] | boolean | number | OIDCEndpoints;
 | `allowedScopes` | `string` | The scopes allowed for the user.                                                                   |
 | `tenantDomain`  | `string` | The tenant domain to which the user belongs.                                                       |
 | `sessionState`  | `string` | The session state.                                                                                 |
+| `sub`           | `string` | The `uid` corresponding to the user who the ID token belongs to.                                    |
 
 In addition to the above attributes, this object will also contain any other claim found in the ID token payload.
 

--- a/README.md
+++ b/README.md
@@ -1075,7 +1075,7 @@ type StoreValue = string | string[] | boolean | number | OIDCEndpoints;
 | `allowedScopes` | `string` | The scopes allowed for the user.                                                                   |
 | `tenantDomain`  | `string` | The tenant domain to which the user belongs.                                                       |
 | `sessionState`  | `string` | The session state.                                                                                 |
-| `sub`           | `string` | The `uid` corresponding to the user who the ID token belongs to.                                    |
+| `sub`           | `string` | The `uid` corresponding to the user to whom the ID token belongs to.                               |
 
 In addition to the above attributes, this object will also contain any other claim found in the ID token payload.
 

--- a/lib/src/core/authentication-core.ts
+++ b/lib/src/core/authentication-core.ts
@@ -443,7 +443,8 @@ export class AuthenticationCore<T> {
 
         let basicUserInfo: BasicUserInfo = {
             allowedScopes: sessionData.scope,
-            sessionState: sessionData.session_state
+            sessionState: sessionData.session_state,
+            sub: authenticatedUser.sub
         };
 
         Object.keys(authenticatedUser).forEach((key) => {

--- a/lib/src/core/authentication-core.ts
+++ b/lib/src/core/authentication-core.ts
@@ -443,8 +443,7 @@ export class AuthenticationCore<T> {
 
         let basicUserInfo: BasicUserInfo = {
             allowedScopes: sessionData.scope,
-            sessionState: sessionData.session_state,
-            sub: authenticatedUser.sub
+            sessionState: sessionData.session_state
         };
 
         Object.keys(authenticatedUser).forEach((key) => {

--- a/lib/src/models/user.ts
+++ b/lib/src/models/user.ts
@@ -16,13 +16,41 @@
 * under the License.
 */
 
+/**
+ * Interface containing the basic user information.
+ */
 export interface BasicUserInfo {
+    /**
+     * The email address of the user.
+     */
     email?: string | undefined;
+    /**
+     * 	The username of the user.
+     */
     username?: string | undefined;
+    /**
+     * The display name of the user. It is the preferred_username in the id token payload or the `sub`.
+     */
     displayName?: string | undefined;
+    /**
+     * The scopes allowed for the user.
+     */
     allowedScopes: string;
+    /**
+     * The tenant domain to which the user belongs.
+     */
     tenantDomain?: string | undefined;
+    /**
+     * The session state.
+     */
     sessionState: string;
+    /**
+     * The `uid` corresponding to the user who the ID token belongs to.
+     */
+    sub: string;
+    /**
+     * Any other attributes retrieved from teh `id_token`.
+     */
     [ key: string ]: any;
 }
 
@@ -55,9 +83,5 @@ export interface AuthenticatedUserInfo {
      * Authenticated user's username.
      */
     username: string;
-    /**
-     * The uid corresponding to the user who the ID token belonged to.
-     */
-    sub: string;
     [key: string]: any;
 }

--- a/lib/src/models/user.ts
+++ b/lib/src/models/user.ts
@@ -47,7 +47,7 @@ export interface BasicUserInfo {
     /**
      * The `uid` corresponding to the user who the ID token belongs to.
      */
-    sub: string;
+    sub?: string;
     /**
      * Any other attributes retrieved from teh `id_token`.
      */

--- a/lib/src/models/user.ts
+++ b/lib/src/models/user.ts
@@ -55,5 +55,9 @@ export interface AuthenticatedUserInfo {
      * Authenticated user's username.
      */
     username: string;
+    /**
+     * The uid corresponding to the user who the ID token belonged to.
+     */
+    sub: string;
     [key: string]: any;
 }

--- a/lib/src/utils/authentication-utils.ts
+++ b/lib/src/utils/authentication-utils.ts
@@ -44,7 +44,7 @@ export class AuthenticationUtils {
             tenantDomain,
             username: username,
             ...this.filterClaimsFromIDTokenPayload(payload)
-        } as AuthenticatedUserInfo;
+        };
     }
 
     private static filterClaimsFromIDTokenPayload(payload: DecodedIDTokenPayload) {

--- a/lib/src/utils/authentication-utils.ts
+++ b/lib/src/utils/authentication-utils.ts
@@ -44,14 +44,13 @@ export class AuthenticationUtils {
             tenantDomain,
             username: username,
             ...this.filterClaimsFromIDTokenPayload(payload)
-        };
+        } as AuthenticatedUserInfo;
     }
 
     private static filterClaimsFromIDTokenPayload(payload: DecodedIDTokenPayload) {
         const optionalizedPayload: Partial<DecodedIDTokenPayload> = { ...payload };
 
         delete optionalizedPayload?.iss;
-        delete optionalizedPayload?.sub;
         delete optionalizedPayload?.aud;
         delete optionalizedPayload?.exp;
         delete optionalizedPayload?.iat;


### PR DESCRIPTION
## Purpose
The `sub` which contains the unique user id of the user in Identity Server is an important attribute that is needed in the application side to persist any stateful information against the user.

## Goals
Return `sub` as a high level attrib when authenticated users details are requested.

Address https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/64

## Approach
Stop dropping `sub` in `filterClaimsFromIDTokenPayload()` function.

## User stories
None

## Release note
None

## Documentation
None

## Training
None

## Certification
None

## Marketing
None

## Automation tests
None

## Security checks
None

## Samples
None

## Related PRs
None

## Migrations (if applicable)
None

## Test environment
None
 
## Learning
None