### PR TITLE
Deprecate getTenantDomainFromIdTokenPayload method

### DIFF
--- a/lib/src/utils/authentication-utils.ts
+++ b/lib/src/utils/authentication-utils.ts
@@ -60,6 +60,9 @@ export class AuthenticationUtils {
         return camelCasedPayload;
     }
 
+    /**
+    * @deprecated since v1.0.6 and will be removed with the v2.0.0 release.
+    */
     public static getTenantDomainFromIdTokenPayload = (
         payload: DecodedIDTokenPayload,
         uidSeparator: string = "@"


### PR DESCRIPTION
## Purpose

This method was used to extract the tenant domain for my account and console using the subject claim of the ID token and this logic worked only when the email is used as the username. 
But ideally this functionality should be located in identity-apps. So transferred the functionality to identity-apps via [1] and deprecate this.

[1] [wso2/identity-apps#2863](https://github.com/wso2/identity-apps/pull/2863)
